### PR TITLE
Fix typo in instructions in Section 'ModelSelector class'

### DIFF
--- a/asl_recognizer.ipynb
+++ b/asl_recognizer.ipynb
@@ -539,7 +539,7 @@
    "metadata": {},
    "source": [
     "#####  ModelSelector class\n",
-    "Review the `SelectorModel` class from the codebase found in the `my_model_selectors.py` module.  It is designed to be a strategy pattern for choosing different model selectors.  For the project submission in this section, subclass `SelectorModel` to implement the following model selectors.  In other words, you will write your own classes/functions in the `my_model_selectors.py` module and run them from this notebook:\n",
+    "Review the `ModelSelector` class from the codebase found in the `my_model_selectors.py` module.  It is designed to be a strategy pattern for choosing different model selectors.  For the project submission in this section, subclass `SelectorModel` to implement the following model selectors.  In other words, you will write your own classes/functions in the `my_model_selectors.py` module and run them from this notebook:\n",
     "\n",
     "- `SelectorCV `:  Log likelihood with CV\n",
     "- `SelectorBIC`: BIC \n",


### PR DESCRIPTION
Hi, 
Reading the instructions, I noticed this minor typo: 'SelectorModel' class should be 'ModelSelector' class.