### PR TITLE
IX Indexer is Deprecated

### DIFF
--- a/asl_recognizer.ipynb
+++ b/asl_recognizer.ipynb
@@ -77,7 +77,7 @@
    },
    "outputs": [],
    "source": [
-    "asl.df.ix[98,1]  # look at the data available for an individual frame"
+    "asl.df.loc[98,1]  # look at the data available for an individual frame"
    ]
   },
   {
@@ -141,7 +141,7 @@
     "# collect the features into a list\n",
     "features_ground = ['grnd-rx','grnd-ry','grnd-lx','grnd-ly']\n",
     " #show a single set of features for a given (video, frame) tuple\n",
-    "[asl.df.ix[98,1][v] for v in features_ground]"
+    "[asl.df.loc[98,1][v] for v in features_ground]"
    ]
   },
   {
@@ -361,21 +361,21 @@
     "class TestFeatures(unittest.TestCase):\n",
     "\n",
     "    def test_features_ground(self):\n",
-    "        sample = (asl.df.ix[98, 1][features_ground]).tolist()\n",
+    "        sample = (asl.df.loc[98, 1][features_ground]).tolist()\n",
     "        self.assertEqual(sample, [9, 113, -12, 119])\n",
     "\n",
     "    def test_features_norm(self):\n",
-    "        sample = (asl.df.ix[98, 1][features_norm]).tolist()\n",
+    "        sample = (asl.df.loc[98, 1][features_norm]).tolist()\n",
     "        np.testing.assert_almost_equal(sample, [ 1.153,  1.663, -0.891,  0.742], 3)\n",
     "\n",
     "    def test_features_polar(self):\n",
-    "        sample = (asl.df.ix[98,1][features_polar]).tolist()\n",
+    "        sample = (asl.df.loc[98,1][features_polar]).tolist()\n",
     "        np.testing.assert_almost_equal(sample, [113.3578, 0.0794, 119.603, -0.1005], 3)\n",
     "\n",
     "    def test_features_delta(self):\n",
-    "        sample = (asl.df.ix[98, 0][features_delta]).tolist()\n",
+    "        sample = (asl.df.loc[98, 0][features_delta]).tolist()\n",
     "        self.assertEqual(sample, [0, 0, 0, 0])\n",
-    "        sample = (asl.df.ix[98, 18][features_delta]).tolist()\n",
+    "        sample = (asl.df.loc[98, 18][features_delta]).tolist()\n",
     "        self.assertTrue(sample in [[-16, -5, -2, 4], [-14, -9, 0, 0]], \"Sample value found was {}\".format(sample))\n",
     "                         \n",
     "suite = unittest.TestLoader().loadTestsFromModule(TestFeatures())\n",


### PR DESCRIPTION
Hi there!
In Pandas, starting in 0.20.0, the .ix indexer is deprecated, in favor of the more strict .iloc and .loc indexers.
The recommended methods of indexing are .loc if you want to label index and .iloc if you want to positionally index.
In this case I propose change .ix in .loc.
source: http://pandas.pydata.org/pandas-docs/stable/indexing.html#ix-indexer-is-deprecated

Marco